### PR TITLE
"ubw-configs.json"->"ubw-configs.js"

### DIFF
--- a/examples/docs/ubw-configs.js
+++ b/examples/docs/ubw-configs.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "blogName": "Sample Blog",
   "blogPath": ".",
   "publicationPath": "../../docs",

--- a/examples/playground/docs/articles/20190209-0001.html
+++ b/examples/playground/docs/articles/20190209-0001.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>My First Article &#x26; Bold | My Blog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="/github-markdown.css">
+    <link rel="stylesheet" href="../github-markdown.css">
   </head>
   <body>
     <div class="markdown-body">

--- a/examples/playground/docs/articles/20190209-0002.html
+++ b/examples/playground/docs/articles/20190209-0002.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>My Second Article &#x26; Bold | My Blog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="/github-markdown.css">
+    <link rel="stylesheet" href="../github-markdown.css">
   </head>
   <body>
     <div class="markdown-body">

--- a/examples/playground/docs/index.html
+++ b/examples/playground/docs/index.html
@@ -4,14 +4,14 @@
     <meta charset="utf-8">
     <title>My Blog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="/github-markdown.css">
+    <link rel="stylesheet" href="./github-markdown.css">
   </head>
   <body>
     <div class="markdown-body">
       <h1>My Blog</h1>
       <ul>
-        <li><a href="articles/20190209-0002.html">My Second Article &#x26; Bold</a></li>
-        <li><a href="articles/20190209-0001.html">My First Article &#x26; Bold</a></li>
+        <li><a href="articles/20190209-0002.html">My Second Article &#x26; Bold</a> 2019-02-09 20:03:02</li>
+        <li><a href="articles/20190209-0001.html">My First Article &#x26; Bold</a> 2019-02-09 20:02:58</li>
       </ul>
     </div>
   </body>

--- a/examples/playground/ubw-configs.js
+++ b/examples/playground/ubw-configs.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "blogName": "My Blog",
   "blogPath": ".",
   "publicationPath": "./docs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export function executeInit(blogRoot: string): Promise<CommandResult> {
   fs.ensureDirSync(blogRoot);
   fs.writeFileSync(
     configFilePath,
-    JSON.stringify(defaultUbwConfigs, null, 2) + '\n'
+    `module.exports = ${JSON.stringify(defaultUbwConfigs, null, 2)}\n`
   );
 
   const paths = generateBlogPaths(blogRoot, defaultUbwConfigs.publicationPath);
@@ -56,7 +56,7 @@ export function executeInit(blogRoot: string): Promise<CommandResult> {
 }
 
 export function executeCompile(configFilePath: string): Promise<CommandResult> {
-  const rawConfigs = fs.readJsonSync(configFilePath);
+  const rawConfigs = require(configFilePath);
   const configs = Object.assign({}, defaultUbwConfigs, rawConfigs) as UbwConfigs;
 
   const blogRoot = path.join(path.dirname(configFilePath), configs.blogPath);
@@ -111,7 +111,7 @@ export function executeCompile(configFilePath: string): Promise<CommandResult> {
 }
 
 export function executeArticleNew(configFilePath: string): Promise<CommandResult> {
-  const rawConfigs = fs.readJsonSync(configFilePath);
+  const rawConfigs = require(configFilePath);
   const configs = Object.assign({}, defaultUbwConfigs, rawConfigs) as UbwConfigs;
 
   const blogRoot = path.join(path.dirname(configFilePath), configs.blogPath);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,7 @@ export const PROJECT_ROOT: string = path.join(__dirname, '..');
 const PRESETS_ROOT: string = path.join(PROJECT_ROOT, 'presets');
 export const PRESETS_STATIC_FILES_ROOT: string = path.join(PRESETS_ROOT, 'static-files');
 
-export const CONFIG_FILE_NAME = 'ubw-configs.json';
+export const CONFIG_FILE_NAME = 'ubw-configs.js';
 
 const RELATIVE_SOURCE_DIR_PATH: string = 'blog-source';
 const RELATIVE_ARTICLES_DIR_PATH: string = 'articles';

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -30,7 +30,7 @@ describe('index', function() {
           assert.strictEqual(result.exitCode, 0);
 
           const dump = dumpDir(workspaceRoot);
-          assert.deepStrictEqual(JSON.parse(dump['ubw-configs.json']), defaultUbwConfigs);
+          assert.strictEqual(typeof dump['ubw-configs.js'], 'string');
           assert.strictEqual(dump['blog-source/static-files/.keep'], '');
         });
     });
@@ -51,7 +51,7 @@ describe('index', function() {
       });
 
       it('can create an article source file', function() {
-        return executeArticleNew(path.join(workspaceRoot, 'ubw-configs.json'))
+        return executeArticleNew(path.join(workspaceRoot, 'ubw-configs.js'))
           .then(result => {
             assert.strictEqual(result.exitCode, 0);
 
@@ -69,7 +69,7 @@ describe('index', function() {
 
       beforeEach(function() {
         clock = sinon.useFakeTimers(new Date(2019, 0, 1));
-        configFilePath = path.join(workspaceRoot, 'ubw-configs.json');
+        configFilePath = path.join(workspaceRoot, 'ubw-configs.js');
 
         return executeInit(workspaceRoot)
           .then(() => executeArticleNew(configFilePath));


### PR DESCRIPTION
特に .js に変更した理由は以下、

- 設定ファイルは、テーマの設定や meta タグのカスタマイズをすることを考慮するとわりと長くなるはず。変数が使えないと可読性に難がある。
- テーマ設定時の React コンポーネントの読み込みで、require が使えると開発がちょい楽になる
- 設定ファイルの各項目にコメントを付与したい
  - これは tsconfigs.json がやってるので、何かライブラリがありそう

デメリットとして、一般的に治安は悪くなる点があげられるけど、大規模や多人数で使うことを想定してないので被害は少なそう。