### PR TITLE
Delete unused "typings" dir

### DIFF
--- a/src/page-generator.ts
+++ b/src/page-generator.ts
@@ -14,22 +14,7 @@ import {
   generateBlogPaths,
 } from './utils';
 
-//
-// TODO:
-//   When executing via reqiure("ts-node").register, the following error occurs.
-//
-//   ```
-//   /path/to/unlimited-blog-works/src/lib/markdowns-converter.ts:17
-//     return hoge.map(markdownSource => {
-//                 ^
-//   TypeError: unified_1.default is not a function
-//   ```
-//
-//   There is no error when passing through "tsc" command directly
-//     (and through "mocha --require ts-settings" command too).
-//
-//   Give up exact typing and confine the influence into this file.
-//
+// NOTICE: "unified" set MUST use only in the file
 const rehypeDocument = require('rehype-document');
 const rehypeFormat = require('rehype-format');
 const rehypeParse = require('rehype-parse');

--- a/src/typings/rehype-document/index.d.ts
+++ b/src/typings/rehype-document/index.d.ts
@@ -1,3 +1,0 @@
-declare module 'rehype-document' {
-  export default function(tree: object[], file: object): void;
-}

--- a/src/typings/rehype-raw/index.d.ts
+++ b/src/typings/rehype-raw/index.d.ts
@@ -1,3 +1,0 @@
-declare module 'rehype-raw' {
-  export default function(tree: object[], file: object): void;
-}

--- a/src/typings/rehype-stringify/index.d.ts
+++ b/src/typings/rehype-stringify/index.d.ts
@@ -1,3 +1,0 @@
-declare module 'rehype-stringify' {
-  export default function(): void;
-}

--- a/src/typings/remark-parse/index.d.ts
+++ b/src/typings/remark-parse/index.d.ts
@@ -1,3 +1,0 @@
-declare module 'remark-parse' {
-  export default function(): void;
-}

--- a/src/typings/remark-rehype/index.d.ts
+++ b/src/typings/remark-rehype/index.d.ts
@@ -1,3 +1,0 @@
-declare module 'remark-rehype' {
-  export default function(tree: object[], file: object): void;
-}

--- a/src/typings/unified/index.d.ts
+++ b/src/typings/unified/index.d.ts
@@ -1,3 +1,0 @@
-declare module 'unified' {
-  export default function(): any;
-}

--- a/tsconfigs/base.json
+++ b/tsconfigs/base.json
@@ -8,12 +8,6 @@
     "module": "commonjs",
     "newLine": "LF",
     "target": "es5",
-    // "ts-node" doesn't use "files", "includes" or "exclude".
-    // https://github.com/TypeStrong/ts-node#help-my-types-are-missing
-    "typeRoots": [
-      "../node_modules/@types",
-      "../src/typings"
-    ],
     /* Strict Type-Checking Options */
     "strict": true,
     /* Additional Checks */


### PR DESCRIPTION
ts-node を通すと tsc を直接実行した時とファイル指定関連（files, include, exclude など）の[挙動が異なり](https://github.com/TypeStrong/ts-node#help-my-types-are-missing)、その回避策として typeRoots を使ったという経緯だった。

ただ、そもそも現在は typings の内容を使ってなく、また今後 unified シリーズに型をつけたいかというと大変なので全然やりたくないので、一旦経緯含めて全部削除する。

なお、どうも本来の解決方法は ts-node に `{file: true}` みたいなオプションがあるらしいので、それを指定することらしい。そうすると、ファイル指定関連が tsc と同じになって、普通に `typings/global.d.ts` などにまとめてかけるとらしい。
