### PR TITLE
Configure additional head tags

### DIFF
--- a/examples/customizing-pages/ubw-configs.js
+++ b/examples/customizing-pages/ubw-configs.js
@@ -25,15 +25,17 @@ const nonArticles = [
   },
 ];
 
-module.exports = {
-  "blogName": "Customizing Pages",
-  "publicationPath": "./blog-publication",
-  "baseUrl": "/",
-  "cssUrls": [
-    "/external-resources/index.css",
-  ],
-  "language": "en",
-  "timeZone": "UTC",
-  renderArticle,
-  nonArticles,
+module.exports = function ubwConfigs() {
+  return {
+    "blogName": "Customizing Pages",
+    "publicationPath": "./blog-publication",
+    "baseUrl": "/",
+    "cssUrls": [
+      "/external-resources/index.css",
+    ],
+    "language": "en",
+    "timeZone": "UTC",
+    renderArticle,
+    nonArticles,
+  };
 }

--- a/examples/docs/ubw-configs.js
+++ b/examples/docs/ubw-configs.js
@@ -1,11 +1,13 @@
-module.exports = {
-  "blogName": "Sample Blog",
-  "blogPath": ".",
-  "publicationPath": "../../docs",
-  "baseUrl": "/unlimited-blog-works/",
-  "cssUrls": [
-    "/unlimited-blog-works/external-resources/index.css",
-  ],
-  "language": "en",
-  "timeZone": "UTC"
+module.exports = function ubwConfigs() {
+  return {
+    "blogName": "Sample Blog",
+    "blogPath": ".",
+    "publicationPath": "../../docs",
+    "baseUrl": "/unlimited-blog-works/",
+    "cssUrls": [
+      "/unlimited-blog-works/external-resources/index.css",
+    ],
+    "language": "en",
+    "timeZone": "UTC"
+  };
 }

--- a/examples/sandbox/ubw-configs.js
+++ b/examples/sandbox/ubw-configs.js
@@ -1,14 +1,16 @@
-module.exports = {
-  "blogName": "わたしのブログ",
-  "blogPath": ".",
-  "publicationPath": "./blog-publication",
-  "baseUrl": "/",
-  "cssUrls": [
-    "/external-resources/index.css",
-  ],
-  "jsUrls": [
-    "/external-resources/index.js",
-  ],
-  "language": "ja",
-  "timeZone": "Asia/Tokyo"
+module.exports = function ubwConfigs() {
+  return {
+    "blogName": "わたしのブログ",
+    "blogPath": ".",
+    "publicationPath": "./blog-publication",
+    "baseUrl": "/",
+    "cssUrls": [
+      "/external-resources/index.css",
+    ],
+    "jsUrls": [
+      "/external-resources/index.js",
+    ],
+    "language": "ja",
+    "timeZone": "Asia/Tokyo"
+  };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -192,6 +192,12 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
+    "callsites": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+      "integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+      "dev": true
+    },
     "ccount": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.3.tgz",
@@ -216,6 +222,16 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
       "integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ=="
+    },
+    "clear-module": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-3.1.0.tgz",
+      "integrity": "sha512-YEe9OX62MYUMjw16Vf2txyzZ3x2ICXNOrjuZ+06MMhnx3fy7V121h9VA3M3bMTtDg8oEfQ2f/fLuhxrSLXS8uw==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
     },
     "collapse-white-space": {
       "version": "1.0.4",
@@ -900,6 +916,15 @@
         }
       }
     },
+    "parent-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
+      "integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "parse-entities": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.0.tgz",
@@ -1141,6 +1166,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
     "resolve-url": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/react": "^16.8.1",
     "@types/react-dom": "^16.0.11",
     "@types/sinon": "^7.0.5",
+    "clear-module": "^3.1.0",
     "http-server": "^0.11.1",
     "klaw-sync": "^6.0.0",
     "mocha": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "remark-frontmatter": "^1.3.1",
     "remark-parse": "^6.0.3",
     "remark-rehype": "^4.0.0",
-    "unified": "^7.1.0"
+    "unified": "^7.1.0",
+    "unist-util-visit": "^1.4.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,10 @@ export function executeInit(blogRoot: string): Promise<CommandResult> {
 
   const configFileSource = [
     'module.exports = function ubwConfigs() {',
-    `return ${JSON.stringify(initialConfigs, null, 2)};`,
+    `return ${JSON.stringify(initialConfigs, null, 2)};`
+      .split('\n')
+      .map(line => '  ' + line)
+      .join('\n'),
     '}',
     '',
   ].join('\n');

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,11 +83,11 @@ export function requireSettings(configFilePath: string): UbwSettings {
 
 export function executeCompile(configFilePath: string): Promise<CommandResult> {
   const settings = requireSettings(configFilePath);
-  return executeCompileWithConfigs(settings);
+  return executeCompileWithSettings(settings);
 }
 
 // Separate it from `executeCompile` to change the `configs` at the time of the test
-export function executeCompileWithConfigs(settings: UbwSettings): Promise<CommandResult> {
+export function executeCompileWithSettings(settings: UbwSettings): Promise<CommandResult> {
   const {
     configs,
     blogRoot,

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,11 +48,15 @@ export function executeInit(blogRoot: string): Promise<CommandResult> {
   const initialConfigs = createInitialUbwConfigs();
   const configs = fillWithDefaultUbwConfigs(initialConfigs);
 
+  const configFileSource = [
+    'module.exports = function ubwConfigs() {',
+    `return ${JSON.stringify(initialConfigs, null, 2)};`,
+    '}',
+    '',
+  ].join('\n');
+
   fs.ensureDirSync(blogRoot);
-  fs.writeFileSync(
-    configFilePath,
-    `module.exports = ${JSON.stringify(initialConfigs, null, 2)}\n`
-  );
+  fs.writeFileSync(configFilePath, configFileSource);
 
   const paths = generateBlogPaths(blogRoot, configs.publicationPath);
 
@@ -71,7 +75,8 @@ export interface UbwSettings {
 }
 
 export function requireSettings(configFilePath: string): UbwSettings {
-  const actualConfigs = require(configFilePath) as ActualUbwConfigs;
+  const generateActualUbwConfigs = require(configFilePath);
+  const actualConfigs = generateActualUbwConfigs() as ActualUbwConfigs;
   const configs = fillWithDefaultUbwConfigs(actualConfigs);
   const blogRoot = path.join(path.dirname(configFilePath), configs.blogPath);
 

--- a/src/page-generator.ts
+++ b/src/page-generator.ts
@@ -349,8 +349,8 @@ export function generateArticlePages(
       .use(createRehypePlugins({
         title: `${articlePage.pageTitle} | ${configs.blogName}`,
         language: configs.language,
-        cssUrls: configs.cssUrls || [],
-        jsUrls: configs.jsUrls || [],
+        cssUrls: configs.cssUrls,
+        jsUrls: configs.jsUrls,
       }))
       .use(rehypeStringify)
       .processSync(articleHtml);
@@ -420,8 +420,8 @@ export function generateNonArticlePages(
       .use(createRehypePlugins({
         title: configs.blogName,
         language: configs.language,
-        cssUrls: configs.cssUrls || [],
-        jsUrls: configs.jsUrls || [],
+        cssUrls: configs.cssUrls,
+        jsUrls: configs.jsUrls,
       }))
       .use(rehypeStringify)
       .processSync(html);

--- a/src/page-generator.ts
+++ b/src/page-generator.ts
@@ -57,16 +57,8 @@ export interface UbwConfigs {
   // These values are assigned to <script src="{here}"> directly.
   // Place these script tags at the end of the body.
   jsUrls: string[],
-  generateArticleHeadNodes: (
-    currentPage: ArticlePage,
-    articlePages: ArticlePage[],
-    nonArticlePages: NonArticlePage[]
-  ) => RehypeAstNode[],
-  generateNonArticleHeadNodes: (
-    currentPage: NonArticlePage,
-    articlePages: ArticlePage[],
-    nonArticlePages: NonArticlePage[]
-  ) => RehypeAstNode[],
+  generateArticleHeadNodes: (articlesProps: ArticlePageProps) => RehypeAstNode[],
+  generateNonArticleHeadNodes: (nonArticlePageProps: NonArticlePageProps) => RehypeAstNode[],
   // Used <html lang="{here}">
   language: string,
   // IANA time zone name (e.g. "America/New_York", "Asia/Tokyo")
@@ -371,7 +363,7 @@ export function generateArticlePages(
         language: configs.language,
         cssUrls: configs.cssUrls,
         jsUrls: configs.jsUrls,
-        additionalHeadNodes: configs.generateArticleHeadNodes(articlePage, articlePages, nonArticlePages),
+        additionalHeadNodes: configs.generateArticleHeadNodes(articlePageProps),
       }))
       .use(rehypeStringify)
       .processSync(articleHtml);
@@ -443,7 +435,7 @@ export function generateNonArticlePages(
         language: configs.language,
         cssUrls: configs.cssUrls,
         jsUrls: configs.jsUrls,
-        additionalHeadNodes: configs.generateNonArticleHeadNodes(nonArticlePage, articlePages, nonArticlePages),
+        additionalHeadNodes: configs.generateNonArticleHeadNodes(nonArticlePageProps),
       }))
       .use(rehypeStringify)
       .processSync(html);

--- a/src/page-generator.ts
+++ b/src/page-generator.ts
@@ -56,6 +56,8 @@ export interface UbwConfigs {
   // These values are assigned to <script src="{here}"> directly.
   // Place these script tags at the end of the body.
   jsUrls: string[],
+  generateArticleHeadTags: (articlePages: ArticlePage[], nonArticlePages: NonArticlePage[]) => string[],
+  generateNonArticleHeadTags: (articlePages: ArticlePage[], nonArticlePages: NonArticlePage[]) => string[],
   // Used <html lang="{here}">
   language: string,
   // IANA time zone name (e.g. "America/New_York", "Asia/Tokyo")
@@ -88,6 +90,12 @@ export function createDefaultUbwConfigs(): UbwConfigs {
       `/${RELATIVE_EXTERNAL_RESOURCES_DIR_PATH}/index.css`,
     ],
     jsUrls: [],
+    generateArticleHeadTags() {
+      return [];
+    },
+    generateNonArticleHeadTags() {
+      return [];
+    },
     language: 'en',
     timeZone: 'UTC',
     renderArticle(props: ArticlePageProps): string {

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -16,6 +16,8 @@ import {
   prepareWorkspace,
 } from '../src/test-helper';
 
+const clearModule = require('clear-module');
+
 describe('index', function() {
   let workspaceRoot: string;
 
@@ -71,12 +73,17 @@ describe('index', function() {
 
       beforeEach(function() {
         clock = sinon.useFakeTimers(new Date('2019-01-01 00:00:00+0000'));
-
         configFilePath = path.join(workspaceRoot, 'ubw-configs.js');
-        settings = requireSettings(configFilePath);
 
         return executeInit(workspaceRoot)
-          .then(() => executeArticleNew(configFilePath));
+          .then(() => {
+            clearModule(configFilePath);
+            settings = requireSettings(configFilePath);
+          })
+          .then(() => {
+            clearModule(configFilePath);
+            return executeArticleNew(configFilePath);
+          });
       });
 
       afterEach(function() {

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -4,9 +4,12 @@ import * as path from 'path';
 import * as sinon from 'sinon';
 
 import {
+  UbwSettings,
   executeArticleNew,
   executeCompile,
+  executeCompileWithConfigs,
   executeInit,
+  requireSettings,
 } from '../src/index';
 import {
   dumpDir,
@@ -60,14 +63,17 @@ describe('index', function() {
     });
   });
 
-  describe('executeCompile', function() {
+  describe('executeCompile, executeCompileWithConfigs', function() {
     describe('when after `executeInit` and `executeArticleNew`', function() {
       let clock: any;
       let configFilePath: string;
+      let settings: UbwSettings;
 
       beforeEach(function() {
         clock = sinon.useFakeTimers(new Date('2019-01-01 00:00:00+0000'));
+
         configFilePath = path.join(workspaceRoot, 'ubw-configs.js');
+        settings = requireSettings(configFilePath);
 
         return executeInit(workspaceRoot)
           .then(() => executeArticleNew(configFilePath));
@@ -78,7 +84,7 @@ describe('index', function() {
       });
 
       it('can create some files into the publication dir', function() {
-        return executeCompile(configFilePath)
+        return executeCompileWithConfigs(settings)
           .then(result => {
             assert.strictEqual(result.exitCode, 0);
 
@@ -95,7 +101,7 @@ describe('index', function() {
         it('should succeed even if there is no "_direct" dir', function() {
           fs.removeSync(path.join(workspaceRoot, 'blog-source/external-resources/_direct'));
 
-          return executeCompile(configFilePath)
+          return executeCompileWithConfigs(settings)
             .then(result => {
               assert.strictEqual(result.exitCode, 0);
 
@@ -108,7 +114,7 @@ describe('index', function() {
         it('should succeed even if the "_direct" dir is empty', function() {
           fs.emptyDirSync(path.join(workspaceRoot, 'blog-source/external-resources/_direct'));
 
-          return executeCompile(configFilePath)
+          return executeCompileWithConfigs(settings)
             .then(result => {
               assert.strictEqual(result.exitCode, 0);
 

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -78,11 +78,10 @@ describe('index', function() {
         return executeInit(workspaceRoot)
           .then(() => {
             clearModule(configFilePath);
-            settings = requireSettings(configFilePath);
+            return executeArticleNew(configFilePath);
           })
           .then(() => {
             clearModule(configFilePath);
-            return executeArticleNew(configFilePath);
           });
       });
 
@@ -90,25 +89,27 @@ describe('index', function() {
         clock.restore();
       });
 
-      it('can create some files into the publication dir', function() {
-        return executeCompileWithSettings(settings)
-          .then(result => {
-            assert.strictEqual(result.exitCode, 0);
+      describe('Basic specification of `executeCompile`', function() {
+        it('can create some files into the publication dir', function() {
+          return executeCompile(configFilePath)
+            .then(result => {
+              assert.strictEqual(result.exitCode, 0);
 
-            const dump = dumpDir(workspaceRoot);
-            assert.strictEqual(typeof dump['blog-publication/index.html'], 'string');
-            assert.strictEqual(typeof dump['blog-publication/robots.txt'], 'string');
-            assert.strictEqual(typeof dump['blog-publication/external-resources/index.css'], 'string');
-            assert.strictEqual(typeof dump['blog-publication/external-resources/github-markdown.css'], 'string');
-            assert.strictEqual(typeof dump['blog-publication/articles/20190101-0001.html'], 'string');
-          });
+              const dump = dumpDir(workspaceRoot);
+              assert.strictEqual(typeof dump['blog-publication/index.html'], 'string');
+              assert.strictEqual(typeof dump['blog-publication/robots.txt'], 'string');
+              assert.strictEqual(typeof dump['blog-publication/external-resources/index.css'], 'string');
+              assert.strictEqual(typeof dump['blog-publication/external-resources/github-markdown.css'], 'string');
+              assert.strictEqual(typeof dump['blog-publication/articles/20190101-0001.html'], 'string');
+            });
+        });
       });
 
       describe('"_direct" directory', function() {
         it('should succeed even if there is no "_direct" dir', function() {
           fs.removeSync(path.join(workspaceRoot, 'blog-source/external-resources/_direct'));
 
-          return executeCompileWithSettings(settings)
+          return executeCompile(configFilePath)
             .then(result => {
               assert.strictEqual(result.exitCode, 0);
 
@@ -121,7 +122,7 @@ describe('index', function() {
         it('should succeed even if the "_direct" dir is empty', function() {
           fs.emptyDirSync(path.join(workspaceRoot, 'blog-source/external-resources/_direct'));
 
-          return executeCompileWithSettings(settings)
+          return executeCompile(configFilePath)
             .then(result => {
               assert.strictEqual(result.exitCode, 0);
 

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -7,7 +7,7 @@ import {
   UbwSettings,
   executeArticleNew,
   executeCompile,
-  executeCompileWithConfigs,
+  executeCompileWithSettings,
   executeInit,
   requireSettings,
 } from '../src/index';
@@ -63,7 +63,7 @@ describe('index', function() {
     });
   });
 
-  describe('executeCompile, executeCompileWithConfigs', function() {
+  describe('executeCompile, executeCompileWithSettings', function() {
     describe('when after `executeInit` and `executeArticleNew`', function() {
       let clock: any;
       let configFilePath: string;
@@ -84,7 +84,7 @@ describe('index', function() {
       });
 
       it('can create some files into the publication dir', function() {
-        return executeCompileWithConfigs(settings)
+        return executeCompileWithSettings(settings)
           .then(result => {
             assert.strictEqual(result.exitCode, 0);
 
@@ -101,7 +101,7 @@ describe('index', function() {
         it('should succeed even if there is no "_direct" dir', function() {
           fs.removeSync(path.join(workspaceRoot, 'blog-source/external-resources/_direct'));
 
-          return executeCompileWithConfigs(settings)
+          return executeCompileWithSettings(settings)
             .then(result => {
               assert.strictEqual(result.exitCode, 0);
 
@@ -114,7 +114,7 @@ describe('index', function() {
         it('should succeed even if the "_direct" dir is empty', function() {
           fs.emptyDirSync(path.join(workspaceRoot, 'blog-source/external-resources/_direct'));
 
-          return executeCompileWithConfigs(settings)
+          return executeCompileWithSettings(settings)
             .then(result => {
               assert.strictEqual(result.exitCode, 0);
 

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -91,30 +91,32 @@ describe('index', function() {
           });
       });
 
-      it('should succeed even if there is no "_direct" dir', function() {
-        fs.removeSync(path.join(workspaceRoot, 'blog-source/external-resources/_direct'));
+      describe('"_direct" directory', function() {
+        it('should succeed even if there is no "_direct" dir', function() {
+          fs.removeSync(path.join(workspaceRoot, 'blog-source/external-resources/_direct'));
 
-        return executeCompile(configFilePath)
-          .then(result => {
-            assert.strictEqual(result.exitCode, 0);
+          return executeCompile(configFilePath)
+            .then(result => {
+              assert.strictEqual(result.exitCode, 0);
 
-            const dump = dumpDir(workspaceRoot);
-            assert.strictEqual(typeof dump['blog-publication/index.html'], 'string');
-            assert.strictEqual(typeof dump['blog-publication/robots.txt'], 'undefined');
-          });
-      });
+              const dump = dumpDir(workspaceRoot);
+              assert.strictEqual(typeof dump['blog-publication/index.html'], 'string');
+              assert.strictEqual(typeof dump['blog-publication/robots.txt'], 'undefined');
+            });
+        });
 
-      it('should succeed even if the "_direct" dir is empty', function() {
-        fs.emptyDirSync(path.join(workspaceRoot, 'blog-source/external-resources/_direct'));
+        it('should succeed even if the "_direct" dir is empty', function() {
+          fs.emptyDirSync(path.join(workspaceRoot, 'blog-source/external-resources/_direct'));
 
-        return executeCompile(configFilePath)
-          .then(result => {
-            assert.strictEqual(result.exitCode, 0);
+          return executeCompile(configFilePath)
+            .then(result => {
+              assert.strictEqual(result.exitCode, 0);
 
-            const dump = dumpDir(workspaceRoot);
-            assert.strictEqual(typeof dump['blog-publication/index.html'], 'string');
-            assert.strictEqual(typeof dump['blog-publication/robots.txt'], 'undefined');
-          });
+              const dump = dumpDir(workspaceRoot);
+              assert.strictEqual(typeof dump['blog-publication/index.html'], 'string');
+              assert.strictEqual(typeof dump['blog-publication/robots.txt'], 'undefined');
+            });
+        });
       });
     });
   });


### PR DESCRIPTION
- GA タグを挿入できるようにしたい
    - 現状の rehype-document の js オプションだと script タグが body 末尾に生える。一方で GA タグ側は head に貼ることを要求しているので無理そう。 → head にタグを追加できる設定値を作ろう。
    - 差し込むタグは生 HTML で定義できると良さそうだが、rehype compiler に差し込むには hastscript syntax tree の書式でしか無理そう。一旦それで指定する形式にする。