### PR TITLE
Rename property names for "file path" and "url"

### DIFF
--- a/examples/customizing-pages/ubw-configs.js
+++ b/examples/customizing-pages/ubw-configs.js
@@ -29,7 +29,7 @@ module.exports = function ubwConfigs() {
   return {
     "blogName": "Customizing Pages",
     "publicationDir": "./blog-publication",
-    "baseUrl": "/",
+    "basePath": "/",
     "cssUrls": [
       "/external-resources/index.css",
     ],

--- a/examples/customizing-pages/ubw-configs.js
+++ b/examples/customizing-pages/ubw-configs.js
@@ -28,7 +28,7 @@ const nonArticles = [
 module.exports = function ubwConfigs() {
   return {
     "blogName": "Customizing Pages",
-    "publicationPath": "./blog-publication",
+    "publicationDir": "./blog-publication",
     "baseUrl": "/",
     "cssUrls": [
       "/external-resources/index.css",

--- a/examples/docs/ubw-configs.js
+++ b/examples/docs/ubw-configs.js
@@ -2,7 +2,7 @@ module.exports = function ubwConfigs() {
   return {
     "blogName": "Sample Blog",
     "publicationDir": "../../docs",
-    "baseUrl": "/unlimited-blog-works/",
+    "basePath": "/unlimited-blog-works/",
     "cssUrls": [
       "/unlimited-blog-works/external-resources/index.css",
     ],

--- a/examples/docs/ubw-configs.js
+++ b/examples/docs/ubw-configs.js
@@ -1,7 +1,6 @@
 module.exports = function ubwConfigs() {
   return {
     "blogName": "Sample Blog",
-    "blogPath": ".",
     "publicationPath": "../../docs",
     "baseUrl": "/unlimited-blog-works/",
     "cssUrls": [

--- a/examples/docs/ubw-configs.js
+++ b/examples/docs/ubw-configs.js
@@ -1,7 +1,7 @@
 module.exports = function ubwConfigs() {
   return {
     "blogName": "Sample Blog",
-    "publicationPath": "../../docs",
+    "publicationDir": "../../docs",
     "baseUrl": "/unlimited-blog-works/",
     "cssUrls": [
       "/unlimited-blog-works/external-resources/index.css",

--- a/examples/sandbox/ubw-configs.js
+++ b/examples/sandbox/ubw-configs.js
@@ -1,7 +1,6 @@
 module.exports = function ubwConfigs() {
   return {
     "blogName": "わたしのブログ",
-    "blogPath": ".",
     "publicationPath": "./blog-publication",
     "baseUrl": "/",
     "cssUrls": [

--- a/examples/sandbox/ubw-configs.js
+++ b/examples/sandbox/ubw-configs.js
@@ -1,7 +1,7 @@
 module.exports = function ubwConfigs() {
   return {
     "blogName": "わたしのブログ",
-    "publicationPath": "./blog-publication",
+    "publicationDir": "./blog-publication",
     "baseUrl": "/",
     "cssUrls": [
       "/external-resources/index.css",

--- a/examples/sandbox/ubw-configs.js
+++ b/examples/sandbox/ubw-configs.js
@@ -2,7 +2,7 @@ module.exports = function ubwConfigs() {
   return {
     "blogName": "わたしのブログ",
     "publicationDir": "./blog-publication",
-    "baseUrl": "/",
+    "basePath": "/",
     "cssUrls": [
       "/external-resources/index.css",
     ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,7 @@ export function requireSettings(configFilePath: string): UbwSettings {
   const generateActualUbwConfigs = require(configFilePath);
   const actualConfigs = generateActualUbwConfigs() as ActualUbwConfigs;
   const configs = fillWithDefaultUbwConfigs(actualConfigs);
-  const blogRoot = path.join(path.dirname(configFilePath), configs.blogPath);
+  const blogRoot = path.join(path.dirname(configFilePath), configs.blogDir);
 
   return {
     configs,

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ export function executeInit(blogRoot: string): Promise<CommandResult> {
   fs.ensureDirSync(blogRoot);
   fs.writeFileSync(configFilePath, configFileSource);
 
-  const paths = generateBlogPaths(blogRoot, configs.publicationPath);
+  const paths = generateBlogPaths(blogRoot, configs.publicationDir);
 
   fs.ensureDirSync(paths.sourceExternalResourcesRoot);
   fs.copySync(PRESETS_EXTERNAL_RESOURCES_ROOT, paths.sourceExternalResourcesRoot);
@@ -100,7 +100,7 @@ export function executeCompileWithSettings(settings: UbwSettings): Promise<Comma
     configs,
     blogRoot,
   } = settings;
-  const paths = generateBlogPaths(blogRoot, configs.publicationPath);
+  const paths = generateBlogPaths(blogRoot, configs.publicationDir);
 
   let articlePages: ArticlePage[] = initializeArticlePages(
       blogRoot, configs, fs.readdirSync(paths.sourceArticlesRoot)
@@ -157,7 +157,7 @@ export function executeArticleNew(configFilePath: string): Promise<CommandResult
     blogRoot,
   } = requireSettings(configFilePath);
 
-  const paths = generateBlogPaths(blogRoot, configs.publicationPath);
+  const paths = generateBlogPaths(blogRoot, configs.publicationDir);
 
   fs.ensureDirSync(paths.sourceRoot);
   fs.ensureDirSync(paths.sourceArticlesRoot);

--- a/src/page-generator.ts
+++ b/src/page-generator.ts
@@ -39,7 +39,7 @@ export interface UbwConfigs {
   blogDir: string,
   // A relative path from the blog root to the publication directory
   publicationDir: string,
-  // A relative URL from the root
+  // A relative url from the root
   //
   // If you want to place the generated "index.html" at "http://your-host.com/index.html", set "/" to this property.
   // If you want to place in "http://your-host.com/subdir/index.html", set "/subdir/" to this property.
@@ -47,7 +47,7 @@ export interface UbwConfigs {
   // In case you are hosting on GitHub,
   // it will be "/" if it is published from the "<username>.github.io" repository,
   // In other cases it will probably be "/<your-repository-name>/".
-  baseUrl: string,
+  basePath: string,
   // Absolute or root-relative urls for CSS sources
   //
   // These values are assigned to <link rel="{here}"> directly.
@@ -71,7 +71,7 @@ export interface UbwConfigs {
     //
     // For example, when the user wishes to use the existing setting, this value is used for identification.
     nonArticlePageId: string,
-    // A relative URL from the "baseUrl"
+    // A relative URL from the "basePath"
     url: string,
     // Non-article pages renderer
     render: (props: NonArticlePageProps) => string,
@@ -86,7 +86,7 @@ export function createDefaultUbwConfigs(): UbwConfigs {
     blogName: 'My Blog',
     blogDir: '.',
     publicationDir: './blog-publication',
-    baseUrl: '/',
+    basePath: '/',
     cssUrls: [
       `/${RELATIVE_EXTERNAL_RESOURCES_DIR_PATH}/index.css`,
     ],
@@ -119,7 +119,7 @@ export function createInitialUbwConfigs(): ActualUbwConfigs {
   return {
     blogName: configs.blogName,
     publicationDir: configs.publicationDir,
-    baseUrl: configs.baseUrl,
+    basePath: configs.basePath,
     cssUrls: configs.cssUrls,
     language: configs.language,
     timeZone: configs.timeZone,
@@ -309,7 +309,7 @@ export function preprocessArticlePages(
     const actualFrontMatters = yaml.safeLoad(frontMattersNode.value) as ActualArticleFrontMatters;
     const frontMatters = fillWithDefaultArticleFrontMatters(actualFrontMatters);
 
-    const permalink = `${configs.baseUrl}${RELATIVE_ARTICLES_DIR_PATH}/${frontMatters.publicId}.html`;
+    const permalink = `${configs.basePath}${RELATIVE_ARTICLES_DIR_PATH}/${frontMatters.publicId}.html`;
 
     return Object.assign({}, articlePage, {
       // TODO: GitHub Pages の仕様で拡張子省略可ならその対応
@@ -384,7 +384,7 @@ export function initializeNonArticlePages(
     return {
       nonArticlePageId: nonArticleConfigs.nonArticlePageId,
       render: nonArticleConfigs.render,
-      permalink: configs.baseUrl + nonArticleConfigs.url,
+      permalink: configs.basePath + nonArticleConfigs.url,
       outputFilePath: path.join(paths.publicationRoot, nonArticleConfigs.url),
       html: '',
     };

--- a/src/page-generator.ts
+++ b/src/page-generator.ts
@@ -38,7 +38,7 @@ export interface UbwConfigs {
   // A relative path from the ubw-configs.js file to the blog root
   blogDir: string,
   // A relative path from the blog root to the publication directory
-  publicationPath: string,
+  publicationDir: string,
   // A relative URL from the root
   //
   // If you want to place the generated "index.html" at "http://your-host.com/index.html", set "/" to this property.
@@ -85,7 +85,7 @@ export function createDefaultUbwConfigs(): UbwConfigs {
   return {
     blogName: 'My Blog',
     blogDir: '.',
-    publicationPath: './blog-publication',
+    publicationDir: './blog-publication',
     baseUrl: '/',
     cssUrls: [
       `/${RELATIVE_EXTERNAL_RESOURCES_DIR_PATH}/index.css`,
@@ -118,7 +118,7 @@ export function createInitialUbwConfigs(): ActualUbwConfigs {
   const configs = createDefaultUbwConfigs();
   return {
     blogName: configs.blogName,
-    publicationPath: configs.publicationPath,
+    publicationDir: configs.publicationDir,
     baseUrl: configs.baseUrl,
     cssUrls: configs.cssUrls,
     language: configs.language,
@@ -254,7 +254,7 @@ export function initializeArticlePages(
   configs: UbwConfigs,
   articleFileNames: string[]
 ): ArticlePage[] {
-  const paths = generateBlogPaths(blogRoot, configs.publicationPath);
+  const paths = generateBlogPaths(blogRoot, configs.publicationDir);
 
   return articleFileNames.map(articleFileName => {
     const articleFilePath = path.join(paths.sourceArticlesRoot, articleFileName);
@@ -292,7 +292,7 @@ export function preprocessArticlePages(
   configs: UbwConfigs,
   articlePages: ArticlePage[]
 ): ArticlePage[] {
-  const paths = generateBlogPaths(blogRoot, configs.publicationPath);
+  const paths = generateBlogPaths(blogRoot, configs.publicationDir);
 
   // NOTE: unified().parse() で生成した Syntax Tree を再利用して、
   //       unified().stringify() で処理する方法が不明だった。
@@ -378,7 +378,7 @@ export function initializeNonArticlePages(
   blogRoot: string,
   configs: UbwConfigs
 ): NonArticlePage[] {
-  const paths = generateBlogPaths(blogRoot, configs.publicationPath);
+  const paths = generateBlogPaths(blogRoot, configs.publicationDir);
 
   return configs.nonArticles.map(nonArticleConfigs => {
     return {
@@ -405,7 +405,7 @@ export function generateNonArticlePages(
   articlePages: ArticlePage[],
   nonArticlePages: NonArticlePage[]
 ): NonArticlePage[] {
-  const paths = generateBlogPaths(blogRoot, configs.publicationPath);
+  const paths = generateBlogPaths(blogRoot, configs.publicationDir);
 
   const articlesProps: NonArticlePageProps['articles'] = articlePages.map(articlePage => {
     return {

--- a/src/page-generator.ts
+++ b/src/page-generator.ts
@@ -35,8 +35,8 @@ const visit = require('unist-util-visit');
 
 export interface UbwConfigs {
   blogName: string,
-  // A relative path from the ubw-configs.json file to the blog root
-  blogPath: string,
+  // A relative path from the ubw-configs.js file to the blog root
+  blogDir: string,
   // A relative path from the blog root to the publication directory
   publicationPath: string,
   // A relative URL from the root
@@ -84,7 +84,7 @@ export interface ActualUbwConfigs extends Partial<UbwConfigs> {
 export function createDefaultUbwConfigs(): UbwConfigs {
   return {
     blogName: 'My Blog',
-    blogPath: '.',
+    blogDir: '.',
     publicationPath: './blog-publication',
     baseUrl: '/',
     cssUrls: [


### PR DESCRIPTION
設定値名は短い方が良いという前提をおいて（ほんとかどうかはわからんが）、ファイルパスやURLを示すものの命名に一定のルール付けを行う。

- "dir" = 基本的にファイルシステム上のディレクトリへの相対パス。たまに、絶対パスも含むかその両方のこともある。
- "file" = 基本的にファイルシステム上のファイルへの相対パス。たまに、絶対パスも含むかその両方のこともある。
- "url" = URL上の絶対URLまたはルート相対パス。
- "path" = URL上の相対パス。