### PR TITLE
Add "article touch" subcommand

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -45,6 +45,15 @@ const commands = {
       : defaultConfigFilePath;
     return ubw.executeArticleNew(configFilePath);
   },
+  'article--touch': ({argv, cwd, defaultConfigFilePath}) => {
+    const options = minimist(argv, appendConfigFileParser({}));
+    const [articleFilePathInput] = options._;
+    const configFilePath = options['config-file']
+      ? ubw.cliUtils.toNormalizedAbsolutePath(options['config-file'], cwd)
+      : defaultConfigFilePath;
+    const articleFilePath = ubw.cliUtils.toNormalizedAbsolutePath(articleFilePathInput, cwd);
+    return ubw.executeArticleTouch(configFilePath, articleFilePath);
+  },
   'compile': ({argv, cwd, defaultConfigFilePath}) => {
     const options = minimist(argv, appendConfigFileParser({}));
     const configFilePath = options['config-file']
@@ -84,6 +93,7 @@ const parsedSubCommands = parseCommands(
       article: {
         commands: {
           new: null,
+          touch: null,
         },
       },
       compile: null,

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,20 @@ export function executeArticleNew(configFilePath: string): Promise<CommandResult
   });
 }
 
+export function executeArticleTouch(configFilePath: string, articleFilePath: string): Promise<CommandResult> {
+  const {
+    configs,
+    blogRoot,
+  } = requireSettings(configFilePath);
+
+  const paths = generateBlogPaths(blogRoot, configs.publicationDir);
+
+  return Promise.resolve({
+    exitCode: 0,
+    message: 'Done "article touch"',
+  });
+}
+
 export function executeCompile(configFilePath: string): Promise<CommandResult> {
   const settings = requireSettings(configFilePath);
   return executeCompileWithSettings(settings);


### PR DESCRIPTION
- 記事の lastUpdateAt を現在時刻へ更新するコマンド
  - publicId もオプションで更新できるようにするのは保留。「更新対象をのぞいて同日のpublicId + 1の連番」を振る必要があるので、実装がわりとめんどくさい。そのわりに特にほしいと思ってない。

----

というのを作ろうとしたけど、今は止めた。

マークダウンソースを生成しないといけないから remark-stringify を入れないといけない。

そして、生成時に他の箇所が変わらないことを保証しないといけないが、そのためには

- [remark-stringify のオプション設定](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify#options) により元の形式を正しく指定するための学習コスト
- 細部に至るまで元のマークダウンソースが復元できる品質を remark-stringify に求めることのリスク

これらのコストやリスクを受け入れることになり、総じてコスパが悪い。

一旦は、「現在時刻を出力するコマンド」を作ることで、保留にする。
また全般的に、記事ソースを出力し直すものは控える。 linter の `--fix` みたいなコマンドならありだけど。